### PR TITLE
innodb_stats_persistent: unless OFF => if ON

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
       Option 1 (permanent): set innodb_stats_on_metadata=ON in my.cnf
       Option 2 (temporary): in mysql CLI, "set global innodb_stats_on_metadata=ON"
     TEXT
-    raise <<-TEXT.strip_heredoc unless variables['innodb_stats_persistent'] == 'OFF'
+    raise <<-TEXT.strip_heredoc if variables['innodb_stats_persistent'] == 'ON'
     innodb_stats_persistent must be OFF
       Option 1 (permanent): set innodb_stats_persistent=OFF in my.cnf
       Option 2 (temporary): in mysql CLI, "set global innodb_stats_persistent=OFF"


### PR DESCRIPTION
innodb_stats_persistent does not exist in MySQL 5.5. This changes makes it backwards compatible.
