### PR TITLE
Correct uaa access_token err when token refresh

### DIFF
--- a/lib/uaa_session.rb
+++ b/lib/uaa_session.rb
@@ -42,7 +42,7 @@ class UaaSession
   end
 
   def access_token
-    token_info.info[:access_token]
+    token_info.info[:access_token] || token_info.info["access_token"]
   end
 
   private


### PR DESCRIPTION
When token expired, it failed when browsing instance's dashboard. Looking into the code, there is the problem in UaaSession.build refreshing token_info.

Before refresh, the access_token is a symbol.
  CF::UAA::TokenInfo:0x007f69fed46380 @info={**:access_token**=>"eyJhbGciOiJSUzI1
After refresh, the access_token is a string.
 CF::UAA::TokenInfo:0x007f69fed5e840 @info={**"access_token"**=>"eyJhbGciOiJ

The type of @info's key is changed but the method [access_token](https://github.com/cloudfoundry/cf-mysql-broker/blob/master/lib/uaa_session.rb#L44) just return symbol type.

This PR refers to [cf-uaa-lib](https://github.com/cloudfoundry/cf-uaa-lib/blob/master/lib/uaa/token_issuer.rb#L38).
