### PR TITLE
The query used to remove and re-add privilleges if a user goes over

### DIFF
--- a/lib/quota_enforcer.rb
+++ b/lib/quota_enforcer.rb
@@ -89,9 +89,8 @@ module QuotaEnforcer
       violators = connection.select_values(<<-SQL)
         SELECT tables.table_schema AS db
         FROM   information_schema.tables AS tables
-        JOIN   mysql.db AS dbs ON tables.table_schema = dbs.Db
+        JOIN   ( SELECT DISTINCT dbs.Db AS Db from mysql.db AS dbs WHERE (dbs.Insert_priv = 'Y' OR dbs.Update_priv = 'Y' OR dbs.Create_priv = 'Y') ) AS dbs ON tables.table_schema = dbs.Db
         JOIN   #{broker_db}.service_instances AS instances ON tables.table_schema = instances.db_name COLLATE utf8_general_ci
-        WHERE  (dbs.Insert_priv = 'Y' OR dbs.Update_priv = 'Y' OR dbs.Create_priv = 'Y')
         GROUP  BY tables.table_schema
         HAVING ROUND(SUM(tables.data_length + tables.index_length) / 1024 / 1024, 1) >= MAX(instances.max_storage_mb)
       SQL
@@ -115,9 +114,8 @@ module QuotaEnforcer
       reformed = connection.select_values(<<-SQL)
         SELECT tables.table_schema AS db
         FROM   information_schema.tables AS tables
-        JOIN   mysql.db AS dbs ON tables.table_schema = dbs.Db
+        JOIN   ( SELECT DISTINCT dbs.Db AS Db from mysql.db AS dbs WHERE (dbs.Insert_priv = 'N' OR dbs.Update_priv = 'N' OR dbs.Create_priv = 'N') ) AS dbs ON tables.table_schema = dbs.Db
         JOIN   #{broker_db}.service_instances AS instances ON tables.table_schema = instances.db_name COLLATE utf8_general_ci
-        WHERE  (dbs.Insert_priv = 'N' OR dbs.Update_priv = 'N' OR dbs.Create_priv = 'N')
         GROUP  BY tables.table_schema
         HAVING ROUND(SUM(tables.data_length + tables.index_length) / 1024 / 1024, 1) < MAX(instances.max_storage_mb)
       SQL

--- a/spec/lib/quota_enforcer_spec.rb
+++ b/spec/lib/quota_enforcer_spec.rb
@@ -16,6 +16,9 @@ describe QuotaEnforcer do
   let(:binding2_id) { SecureRandom.uuid }
   let(:binding2) { ServiceBinding.new(id: binding2_id, service_instance: instance2) }
 
+  let(:binding3_id) { SecureRandom.uuid }
+  let(:binding3) { ServiceBinding.new(id: binding3_id, service_instance: instance1) }
+
   let(:bindings) { [binding1, binding2] }
 
   let(:service) { Service.build(
@@ -60,12 +63,14 @@ describe QuotaEnforcer do
     ServiceInstanceManager.create(guid: instance2_guid, plan_guid: 'plan-2-guid' )
     binding1.save
     binding2.save
+    binding3.save
 
     # No instance / binding for plan 3 to test enforcer works for plans with no instance
   end
 
   after do
     bindings.each { |binding| binding.destroy }
+    binding3.destroy
     ServiceInstanceManager.destroy(guid: instance1_guid)
     ServiceInstanceManager.destroy(guid: instance2_guid)
   end


### PR DESCRIPTION
their plan space is flawed.

If only a single user is bound to an instance (like in the previous
test cases) the query would be correct. If mulitple users were bound
it would multiply the actual usage by the number of users.
(e.g. 5mb space used with 5 users would report as 25mb space used).

This is due to including the mysql.db table in the query which could
end up with mulitple entries for multiple users.

The "SUM(tables.data_length + tables.index_length)" then
keeps counting the same rows repeatedly.

I have replaced joining with the dbs.Db table with a temporary
distinct table and added a second bound user to the test cases.
