### PR TITLE
Correct MySQL jdbcUrl format

### DIFF
--- a/app/models/service_binding.rb
+++ b/app/models/service_binding.rb
@@ -144,6 +144,6 @@ class ServiceBinding < BaseModel
   end
 
   def jdbc_url
-    "jdbc:mysql://#{username}:#{password}@#{host}:#{port}/#{database_name}"
+    "jdbc:mysql://#{host}:#{port}/#{database_name}?user=#{username}&password=#{password}"
   end
 end

--- a/spec/controllers/v2/service_bindings_controller_spec.rb
+++ b/spec/controllers/v2/service_bindings_controller_spec.rb
@@ -54,7 +54,7 @@ describe V2::ServiceBindingsController do
         'username' => generated_username,
         'password' => generated_password,
         'port' => database_port,
-        'jdbcUrl' => "jdbc:mysql://#{generated_username}:#{generated_password}@#{database_host}:#{database_port}/#{generated_dbname}",
+        'jdbcUrl' => "jdbc:mysql://#{database_host}:#{database_port}/#{generated_dbname}?user=#{generated_username}&password=#{generated_password}",
         'uri' => "mysql://#{generated_username}:#{generated_password}@#{database_host}:#{database_port}/#{generated_dbname}?reconnect=true",
       )
     end

--- a/spec/models/service_binding_spec.rb
+++ b/spec/models/service_binding_spec.rb
@@ -213,7 +213,7 @@ describe ServiceBinding do
     let(:host) { connection_config.fetch('host') }
     let(:port) { connection_config.fetch('port') }
     let(:uri) { "mysql://#{username}:#{password}@#{host}:#{port}/#{database}?reconnect=true" }
-    let(:jdbc_url) { "jdbc:mysql://#{username}:#{password}@#{host}:#{port}/#{database}" }
+    let(:jdbc_url) { "jdbc:mysql://#{host}:#{port}/#{database}?user=#{username}&password=#{password}" }
 
     before { binding.save }
 

--- a/spec/requests/lifecycle_spec.rb
+++ b/spec/requests/lifecycle_spec.rb
@@ -66,7 +66,7 @@ describe 'the service lifecycle' do
       'username' => username,
       'password' => password,
       'port' => 3306,
-      'jdbcUrl' => "jdbc:mysql://#{username}:#{password}@localhost:3306/#{dbname}",
+      'jdbcUrl' => "jdbc:mysql://localhost:3306/#{dbname}?user=#{username}&password=#{password}",
       'uri' => "mysql://#{username}:#{password}@localhost:3306/#{dbname}?reconnect=true",
     })
 


### PR DESCRIPTION
The MySQL JDBC driver will not accept `jdbcUrl` produced by the broker. The correct format is:
`jdbc:mysql://[host][,failoverhost...][:port]/[database][?propertyName1][=propertyValue1]...`
quoting http://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html

Sample error:

```
2014-09-29T21:01:24.63+0000 [App/0]   OUT Caused by: java.lang.NumberFormatException: For input string: "rqzUzkIxACpoKQup@10.0.1.61:3306"
"p-mysql": [
    {
      "name": "mysql-1",
      "label": "p-mysql",
      "tags": [
        "mysql"
      ],
      "plan": "100mb-dev",
      "credentials": {
        "hostname": "10.0.1.61",
        "port": 3306,
        "name": "cf_4840c037_d78f_4dcf_9a7b_7d1b9fc08e80",
        "username": "H4iJMTnrtW7zdx5m",
        "password": "rqzUzkIxACpoKQup",
        "uri": "mysql://H4iJMTnrtW7zdx5m:rqzUzkIxACpoKQup@10.0.1.61:3306/cf_4840c037_d78f_4dcf_9a7b_7d1b9fc08e80?reconnect=true",
        "jdbcUrl": "jdbc:mysql://H4iJMTnrtW7zdx5m:rqzUzkIxACpoKQup@10.0.1.61:3306/cf_4840c037_d78f_4dcf_9a7b_7d1b9fc08e80"
      }
    }
  ],
```
