### PR TITLE
Allow any 2.3+ ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '~> 2.3'
 
 gem 'rails', '4.2.7.1'
 gem 'rails-api'


### PR DESCRIPTION
This allows ruby versions such as 2.3.3 to be used, but not 3.0+

@mdelillo @markymarkmcdonald