### PR TITLE
Manage paid and free plan

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,5 +1,5 @@
 class Plan
-  attr_reader :id, :name, :description, :metadata, :max_storage_mb, :max_user_connections
+  attr_reader :id, :name, :description, :metadata, :max_storage_mb, :max_user_connections, :free
 
   def self.build(attrs)
     new(attrs)
@@ -12,6 +12,7 @@ class Plan
     @metadata    = attrs.fetch('metadata', nil)
     @max_storage_mb = attrs.fetch('max_storage_mb', nil)
     @max_user_connections = attrs.fetch('max_user_connections', nil)
+    @free        = attrs.fetch('free',true)
   end
 
   def to_hash
@@ -20,6 +21,7 @@ class Plan
       'name'        => self.name,
       'description' => self.description,
       'metadata'    => self.metadata,
+      'free'        => self.free,
     }
   end
 end


### PR DESCRIPTION
### Can not display the cost associated with a plan in the Cloudfoundry marketplace  
The Mysql Service Broker does not manage the "**free**" field in the service catalog (`/v2/catalog`).
This field allows the management of the price display associated with the plan in the Cloudfoundry marketplace (https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#plan-object)
`| free | boolean | When false, Service Instances of this plan have a cost. The default is true. |`

This PR resolves this dysfunction.
